### PR TITLE
Fix type error in Page component by adding explicit type annotation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,9 @@
 import { fetchCars } from "@/utils";
 import { fuels, yearsOfProduction } from "@/constants";
 import { CarCard, ShowMore, SearchBar, CustomFilter, Hero } from "@/components";
+import { SearchParamsProps } from "@/types";
 
-export default async function Home({ searchParams }) {
+export default async function Home({ searchParams }: { searchParams: SearchParamsProps }) {
   const allCars = await fetchCars({
     manufacturer: searchParams.manufacturer || "",
     year: searchParams.year || 2022,

--- a/types/index.ts
+++ b/types/index.ts
@@ -52,3 +52,11 @@ export interface OptionProps {
     pageNumber: number;
     isNext: boolean;
   }
+
+  export interface SearchParamsProps {
+    manufacturer?: string;
+    year?: number;
+    fuel?: string;
+    limit?: number;
+    model?: string;
+  }


### PR DESCRIPTION
This pull request fixes a type error in the Page component by adding an explicit type annotation for the `searchParams` parameter. Previously, the code had an implicit 'any' type for `searchParams`, leading to a compilation error during the build process. By introducing the `SearchParamsProps` type and applying the necessary type annotations, the code now compiles successfully without any type errors.